### PR TITLE
Trivial fix to arguments for LuceneQuery.add()

### DIFF
--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -263,7 +263,7 @@ class LuceneQuery(object):
         q._pow = value
         return q
         
-    def add(self, args, kwargs, terms_or_phrases=None):
+    def add(self, args, kwargs):
         self.normalized = False
         _args = []
         for arg in args:


### PR DESCRIPTION
The LuceneQuery.add() terms_or_phrases argument is never used, so it probably shouldn't be in the header.  If this was there for backwards compatibility, it should probably be used, instead of applying this commit.
