### PR TITLE
make solr highlighting results available on the individual result items

### DIFF
--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -469,6 +469,19 @@ class BaseSearch(object):
     def transform_result(self, result, constructor):
         if constructor is not dict:
             result.result.docs = [constructor(**d) for d in result.result.docs]
+            # perhaps make highlighting available in custom results if
+            # the class provides a set_highlighting method or some such ?
+        else:
+            if result.highlighting:
+                for d in result.result.docs:
+                    # if the unique key for a result doc is present in highlighting,
+                    # add the highlighting for that document into the result dict
+                    # (but don't override any existing content)
+                    if 'highlighting' not in d and \
+                           d[self.schema.unique_key] in result.highlighting:
+                        d['highlighting'] = result.highlighting[d[self.schema.unique_key]]
+                        # NOTE: should this be a more unique field
+                        # name to reduce potential conflicts?
         return result
 
     def params(self):


### PR DESCRIPTION
This may be a naive implementation, but I'm having trouble figuring out another way to approach this (and my solution is working for my use case).

The particular reason why this matters for me: if I paginate search results with a django paginator, it's a bit tricky to get back to the highlighting results.  And even when I get to them, it's a little bit of a pain linking the result document with the appropriate highlighting snippets (particularly in a django template).  However, I imagine there are other cases where this would be useful, too.
