### PR TITLE
per-item highlights on individual result items (with docs & tests)

### DIFF
--- a/docs/queryingsolr.rst
+++ b/docs/queryingsolr.rst
@@ -753,7 +753,31 @@ The results are shown as a dictionary of dictionaries. The top-level key is the 
 mapping field names to fragments of highlighted text. In this case we only asked for
 highlighting on the ``name`` field. Multiple fragments might be returned for each field,
 though in this case we only get one fragment each. The text is highlighted with HTML, and
-the fragments should be suitable for dropping straight into a search template.
+the fragments should be suitable for dropping straight into a search
+template.
+
+If you are using the default result format (that is, if you are not
+specifying a ``constructor`` option when you call
+:meth:`~sunburnt.search.SolrSearch.execute`), highlighting results for
+a single result can be accessed on the individual result item as a
+dictionary in a ``solr_highlights`` field.  For example, with the
+highlighted query above, you could access highlight snippets for the
+``name`` field on an individual result as
+``result['solr_highlights']['name']``.  This is particularly
+convenient for displaying highlighted text snippets in a template;
+e.g., displaying highlights in a Django template might look like this:
+
+::
+    
+  {% for snippet in book.solr_highlights.name %}
+     <p>... {{ snippet|safe }} ...</p>
+  {% endfor %}
+
+.. Note::
+
+  The ``solr_highlights`` field will only be available on a result
+  item if highlights were found for that record.
+
 
 Again, Solr supports a large number of options to the highlighting command,
 and all of these are exposed through sunburnt. The full list of supported options is:

--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -469,6 +469,19 @@ class BaseSearch(object):
     def transform_result(self, result, constructor):
         if constructor is not dict:
             result.result.docs = [constructor(**d) for d in result.result.docs]
+            # in future, highlighting chould be made available to
+            # custom constructors; perhaps document additional
+            # arguments result constructors are required to support, or check for
+            # an optional set_highlighting method
+        else:
+            if result.highlighting:
+                for d in result.result.docs:
+                    # if the unique key for a result doc is present in highlighting,
+                    # add the highlighting for that document into the result dict
+                    # (but don't override any existing content)
+                    if 'solr_highlights' not in d and \
+                           d[self.schema.unique_key] in result.highlighting:
+                        d['solr_highlights'] = result.highlighting[d[self.schema.unique_key]]
         return result
 
     def params(self):


### PR DESCRIPTION
Revised version of my prior pull request for this feature ( https://github.com/tow/sunburnt/pull/33 ), now with documentation and tests.  I went with a field name of "solr_highlights" instead of "solr:highlights" because the : in the field name (while guaranteeing it won't collide with an existing field name) is also problematic (read: impossible to use) in Django templates, which is my primary motivation for adding this. 

Hope the tests are general what you were looking for; hope the docs are clear without being too Django specific.  --I tried to also draw on the examples in posts to the google group.

Hope you don't have to do much revision.
