### PR TITLE
Fix handling of dates.

### DIFF
--- a/sunburnt/json.py
+++ b/sunburnt/json.py
@@ -12,12 +12,16 @@ class SunburntJSONEncoder(json.JSONEncoder):
         return super(SunburntJSONEncoder, self).encode(o)
         
     def default(self, obj):
+        if hasattr(obj, 'isoformat'):
+            return "%sZ" % (obj.replace(tzinfo=None).isoformat(), )
         if hasattr(obj, "strftime"):
             try:
                 microsecond = obj.microsecond
             except AttributeError:
                 microsecond = int(1000000*math.modf(obj.second)[0])
-            return u"%s.%sZ" % (obj.isoformat(), microsecond)
+            if microsecond:
+                return u"%s.%sZ" % (obj.strftime("%Y-%m-%dT%H:%M:%S"), microsecond)
+            return u"%sZ" % (obj.strftime("%Y-%m-%dT%H:%M:%S"),)
         return super(SunburntJSONEncoder, self).default(obj)
 
 def dump(obj, fp, *args, **kwargs):

--- a/sunburnt/schema.py
+++ b/sunburnt/schema.py
@@ -49,7 +49,7 @@ class solr_date(object):
         if hasattr(dt_obj, 'tzinfo') and dt_obj.tzinfo:
             # but Solr requires UTC times.
             if pytz:
-                return dt_obj.astimezone(pytz.utc)
+                return dt_obj.astimezone(pytz.utc).replace(tzinfo=None)
             else:
                 raise EnvironmentError("pytz not available, cannot do timezone conversions")
         else:
@@ -69,8 +69,13 @@ class solr_date(object):
         """ Serialize a datetime object in the format required
         by Solr. See http://wiki.apache.org/solr/IndexingDates
         """
-        return u"%s.%sZ" % (self._dt_obj.isoformat(),
-                            "%06d" % self.microsecond)
+        if hasattr(self._dt_obj, 'isoformat'):
+            return "%sZ" % (self._dt_obj.isoformat(), )
+        strtime = self._dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+        microsecond = self.microsecond
+        if microsecond:
+            return u"%s.%06dZ" % (strtime, microsecond)
+        return u"%sZ" % (strtime,)
 
     def __cmp__(self, other):
         try:

--- a/sunburnt/test_schema.py
+++ b/sunburnt/test_schema.py
@@ -21,10 +21,10 @@ samples_from_pydatetimes = {
     "2009-07-23T00:24:34.000376Z":
         [not_utc.localize(datetime.datetime(2009, 07, 23, 3, 24, 34, 376)),
          datetime.datetime(2009, 07, 23, 0, 24, 34, 376, pytz.utc)],
-    "2009-07-23T03:24:34.000000Z":
+    "2009-07-23T03:24:34Z":
         [datetime.datetime(2009, 07, 23, 3, 24, 34),
          datetime.datetime(2009, 07, 23, 3, 24, 34, tzinfo=pytz.utc)],
-    "2009-07-23T00:24:34.000000Z":
+    "2009-07-23T00:24:34Z":
         [not_utc.localize(datetime.datetime(2009, 07, 23, 3, 24, 34)),
          datetime.datetime(2009, 07, 23, 0, 24, 34, tzinfo=pytz.utc)]
     }
@@ -33,7 +33,7 @@ samples_from_mxdatetimes = {
     "2009-07-23T03:24:34.000376Z":
         [mx.DateTime.DateTime(2009, 07, 23, 3, 24, 34.000376),
          datetime.datetime(2009, 07, 23, 3, 24, 34, 376, pytz.utc)],
-    "2009-07-23T03:24:34.000000Z":
+    "2009-07-23T03:24:34Z":
         [mx.DateTime.DateTime(2009, 07, 23, 3, 24, 34),
          datetime.datetime(2009, 07, 23, 3, 24, 34, tzinfo=pytz.utc)],
     }
@@ -50,7 +50,7 @@ samples_from_strings = {
     }
 
 def check_solr_date_from_date(s, date, canonical_date):
-    assert unicode(solr_date(date)) == s
+    assert unicode(solr_date(date)) == s, "Unequal representations of %r: %r and %r" % (date, unicode(solr_date(date)), s)
     check_solr_date_from_string(s, canonical_date)
 
 def check_solr_date_from_string(s, date):

--- a/sunburnt/test_search.py
+++ b/sunburnt/test_search.py
@@ -176,9 +176,9 @@ good_query_data = {
         ([], {"sdouble_field":3}, # casting from int should work
          {"q":u"sdouble_field:3.0"}),
         ([], {"date_field":datetime.datetime(2009, 1, 1)},
-         {"q":u"date_field:2009-01-01T00\\:00\\:00.000000Z"}),
+         {"q":u"date_field:2009-01-01T00\\:00\\:00Z"}),
         ([], {"date_field":mx.DateTime.DateTime(2009, 1, 1)},
-         {"q":u"date_field:2009-01-01T00\\:00\\:00.000000Z"}),
+         {"q":u"date_field:2009-01-01T00\\:00\\:00Z"}),
         ),
 
     "query":(
@@ -201,17 +201,17 @@ good_query_data = {
         ([], {"int_field__range":(3, -3)},
          [("q", u"int_field:[\-3 TO 3]")]),
         ([], {"date_field__lt":datetime.datetime(2009, 1, 1)},
-         [("q", u"date_field:{* TO 2009\\-01\\-01T00\\:00\\:00.000000Z}")]),
+         [("q", u"date_field:{* TO 2009\\-01\\-01T00\\:00\\:00Z}")]),
         ([], {"date_field__gt":datetime.datetime(2009, 1, 1)},
-         [("q", u"date_field:{2009\\-01\\-01T00\\:00\\:00.000000Z TO *}")]),
+         [("q", u"date_field:{2009\\-01\\-01T00\\:00\\:00Z TO *}")]),
         ([], {"date_field__rangeexc":(datetime.datetime(2009, 1, 1), datetime.datetime(2009, 1, 2))},
-         [("q", "date_field:{2009\\-01\\-01T00\\:00\\:00.000000Z TO 2009\\-01\\-02T00\\:00\\:00.000000Z}")]),
+         [("q", "date_field:{2009\\-01\\-01T00\\:00\\:00Z TO 2009\\-01\\-02T00\\:00\\:00Z}")]),
         ([], {"date_field__lte":datetime.datetime(2009, 1, 1)},
-         [("q", u"date_field:[* TO 2009\\-01\\-01T00\\:00\\:00.000000Z]")]),
+         [("q", u"date_field:[* TO 2009\\-01\\-01T00\\:00\\:00Z]")]),
         ([], {"date_field__gte":datetime.datetime(2009, 1, 1)},
-         [("q", u"date_field:[2009\\-01\\-01T00\\:00\\:00.000000Z TO *]")]),
+         [("q", u"date_field:[2009\\-01\\-01T00\\:00\\:00Z TO *]")]),
         ([], {"date_field__range":(datetime.datetime(2009, 1, 1), datetime.datetime(2009, 1, 2))},
-         [("q", u"date_field:[2009\\-01\\-01T00\\:00\\:00.000000Z TO 2009\\-01\\-02T00\\:00\\:00.000000Z]")]),
+         [("q", u"date_field:[2009\\-01\\-01T00\\:00\\:00Z TO 2009\\-01\\-02T00\\:00\\:00Z]")]),
         ([], {'string_field':['hello world', 'goodbye, cruel world']},
          [("q", u"string_field:goodbye,\\ cruel\\ world AND string_field:hello\\ world")]),
         # Raw strings
@@ -224,7 +224,7 @@ def check_query_data(method, args, kwargs, output):
     solr_search = SolrSearch(interface)
     p = getattr(solr_search, method)(*args, **kwargs).params()
     try:
-        assert p == output
+        assert p == output, "Unequal: %r, %r" % (p, output)
     except AssertionError:
         if debug:
             print p


### PR DESCRIPTION
Various tests, and untested cases, have been failing since #39 was
merged.  This patch fixes the following:

mx.DateTime dates were failing with AttributeError due to not having an
isotime method.  To fix this, we check for the isotime attribute before
using it.

handling of dates with timezones attached was failing; the 00:00 from
the timezone was being included in the output, making them invalid
(particularly when the Z was appended).  To fix this, we remove the
timezone information after using pytz to force the timezone to be UTC.

handling of datetime objects with millisecond values was failing, since
isotime() includes the millisecond component if it is non-0, and
therefore the millisecond value was being output twice.  To fix this, we
just use the raw isotime() output (but append the Z).
