### PR TITLE
Error when using commitWithin parameter

### DIFF
--- a/sunburnt/sunburnt.py
+++ b/sunburnt/sunburnt.py
@@ -70,7 +70,7 @@ class SolrConnection(object):
             extra_params['commit'] = "true" if commit else "false"
         if commitWithin is not None:
             try:
-                extra_params['commitWithin'] = str(float(commitWithin))
+                extra_params['commitWithin'] = str(int(commitWithin))
             except (TypeError, ValueError):
                 raise ValueError("commitWithin should be a number in milliseconds")
             if extra_params['commitWithin'] < 0:


### PR DESCRIPTION
sunburnt throws an error, when `commitWithin` parameter is provided, while adding a new document. 

For example

``` python
import sunburnt
si = sunburnt.SolrInterface("http://localhost:8983/solr/")
si.add({"id": 432, "text": "Hello World!"}, commitWithin=10000)
```

The error message thrown is 

SolrError: ({'transfer-encoding': 'chunked', 'status': '400', 'content-type': 'application/xml; charset=UTF-8'}, '<?xml version="1.0" encoding="UTF-8"?>\n<response>\n<lst name="responseHeader"><int name="status">400</int><int name="QTime">0</int></lst><lst name="error"><str name="msg">For input string: "10000.0"</str><int name="code">400</int></lst>\n</response>\n')

This is happening because commitWithin parameter is converted to `float` before the request is sent.
