### PR TITLE
Escape forward slash characters in Solr strings for Solr 4+

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 * 0.7 : unreleased
+ - Escape forward slash characters for compatibility with Solr 4.0 (@davidjb)
  - Fix handling of queries with ``boost_relevancy`` applied - boost was 
    previously lost in some cases. (@davidjb)
  - Ensure 'more like this' results are transformed using a query's

--- a/sunburnt/strings.py
+++ b/sunburnt/strings.py
@@ -5,7 +5,7 @@ class SolrString(unicode):
     # The behaviour below is only really relevant for String fields rather
     # than Text fields - most queryparsers will strip these characters out
     # for a text field anyway.
-    lucene_special_chars = '+-&|!(){}[]^"~*?: \t\v\\'
+    lucene_special_chars = '+-&|!(){}[]^"~*?: \t\v\\/'
     def escape_for_lqs_term(self):
         if self in ["AND", "OR", "NOT", ""]:
             return u'"%s"' % self

--- a/sunburnt/test_strings.py
+++ b/sunburnt/test_strings.py
@@ -1,0 +1,11 @@
+from .strings import RawString
+
+
+def test_string_escape():
+    """ Ensure that string characters are escaped correctly for Solr queries.
+    """
+    test_str = u'+-&|!(){}[]^"~*?: \t\v\\/'
+    escaped = RawString(test_str).escape_for_lqs_term()
+    assert escaped == u'\\+\\-\\&\\|\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\ \\\t\\\x0b\\\\\\/'
+
+


### PR DESCRIPTION
I've been testing Sunburnt (master on GitHub) with Solr 4 and so far almost everything works.  However, queries with  '/' (forward slash) characters have issues since they are now special characters and need to be escaped (see http://wiki.apache.org/solr/SolrQuerySyntax#Default_QParserPlugin:_LuceneQParserPlugin). This can be easily fixed by this pull request. 

Backwards compatibility is maintained as Solr 3 query terms can have any characters escaped without affecting the query.
