### PR TITLE
Fix boost_relevancy handling for some queries

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 * 0.7 : unreleased
+ - Fix handling of queries with ``boost_relevancy`` applied - boost was 
+   previously lost in some cases. (@davidjb)
  - Ensure 'more like this' results are transformed using a query's
    execute() `constructor`, as are normal query results. (@davidjb)
 

--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -170,7 +170,8 @@ class LuceneQuery(object):
                 self = newself
                 mutated = True
         elif self._and or self._or:
-            if not self.terms and not self.phrases and not self.ranges:
+            if not self.terms and not self.phrases and not self.ranges \
+               and not self.boosts:
                 if len(self.subqueries) == 1:
                     self = self.subqueries[0]
                     mutated = True

--- a/sunburnt/test_search.py
+++ b/sunburnt/test_search.py
@@ -476,8 +476,12 @@ complex_boolean_queries = (
 # And boost_relevancy
     (lambda q: q.query("blah").boost_relevancy(1.5, int_field=3),
      [('q', u'blah OR (blah AND int_field:3^1.5)')]),
+    (lambda q: q.query("blah").boost_relevancy(1.5, int_field=3).boost_relevancy(2, string_field='def'),
+     [('q', u'blah OR (blah AND (int_field:3^1.5 OR string_field:def^2))')]),
     (lambda q: q.query("blah").query("blah2").boost_relevancy(1.5, int_field=3),
      [('q', u'(blah AND blah2) OR (blah AND blah2 AND int_field:3^1.5)')]),
+    (lambda q: q.query(q.Q("blah") | q.Q("blah2")).boost_relevancy(1.5, int_field=3),
+     [('q', u'blah OR blah2 OR ((blah OR blah2) AND int_field:3^1.5)')]),
 # And ranges
     (lambda q: q.query(int_field__any=True),
      [('q', u'int_field:[* TO *]')]),


### PR DESCRIPTION
Certain types of queries -- in particular, ones that consist of one set `OR`'ed fields that produce, under the hood, a `query_obj` that contain a single subquery -- were seeing their boosts (ones applied by `boost_frequency`) being lost at execution time.

The reason for this was that when being normalised, this type of query finds itself being replaced (due to code at https://github.com/tow/sunburnt/blob/master/sunburnt/search.py#L175).  This replacement causes any boosts applied with the `boost_relevancy` function to be be lost as they were originally only present on the top-level query.

This pull request avoids this behaviour during normalisation and adds tests accordingly.  It also adds another test to check for results after multiple calls to boost_relevancy for a query.
