### PR TITLE
Provide default string-based field for schema field types unknown to Sunburnt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 .cache
 MANIFEST
 build

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
 * 0.7 : unreleased
+ - Provide default string-based field for schema field types unknown to
  - Escape forward slash characters for compatibility with Solr 4.0 (@davidjb)
+   Sunburnt. (@davidjb)
  - Fix handling of queries with ``boost_relevancy`` applied - boost was 
    previously lost in some cases. (@davidjb)
  - Ensure 'more like this' results are transformed using a query's

--- a/docs/connectionconfiguration.rst
+++ b/docs/connectionconfiguration.rst
@@ -27,6 +27,51 @@ parameters.
   currently active schema. If you want to use a different schema for
   any reason, pass in a file object here which yields a schema
   document.
+ 
+  In querying the current active schema, sunburnt will automatically
+  understand the available fields and their respective types.  Sunburnt
+  has a variety of field helpers that automatically serialize and
+  deserialize data types behind the scenes (such as when querying Solr
+  and parsing a response).  For instance, this means that if you have a
+  field ``quantity`` in your schema with type ``solr.IntField``, Sunburnt
+  is aware that values of this field are integers. So, values going to Solr
+  in a query will get serialized into an appropriate string, and those coming
+  back as strings will be deserialized as ``int`` values.
+
+  Most built-in Solr field types (in the ``solr.*`` namespace) are understood,
+  including:
+
+  ========================  ===========
+  Field Type                Python Type
+  ========================  ===========
+  solr.StrField             unicode
+  solr.TextField            unicode
+  solr.BoolField            bool
+  solr.ShortField           int (-32768 to 32767)
+  solr.IntField             int
+  solr.SortableIntField     int
+  solr.TrieIntField         int
+  solr.LongField            long
+  solr.SortableLongField    long
+  solr.TrieLongField        long
+  solr.FloatField           float
+  solr.SortableFloatField   float
+  solr.TrieFloatField       float
+  solr.DoubleField          float
+  solr.SortableDoubleField  float
+  solr.TrieDoubleField      float
+  solr.DateField            datetime (or mx.DateTime)
+  solr.TrieDateField        datetime (or mx.DateTime)
+  solr.RandomSortField      str (default handling)
+  solr.UUIDField            uuid.UUID
+  solr.BinaryField          unicode (base64 decoded)
+  solr.PointType            solr_point (1 dimension)
+  solr.LatLonType           solr_point (2 dimensions)
+  solr.GeoHashField         solr_point (2 dimensions)
+  ========================  =========== 
+
+  If you are using a custom field type that Sunburnt does not
+  natively understand, values will be treated as strings.
 
 * ``http_connection``. By default, solr will open a new ``httplib2.Http``
   object to talk to the solr instance. If you want to re-use an

--- a/sunburnt/schema.py
+++ b/sunburnt/schema.py
@@ -147,6 +147,14 @@ class SolrField(object):
             else:
                 return name.startswith(self.name[:-1])
 
+    def normalize(self, value):
+        """ Normalize the given value according to the field type.
+        
+        This method does nothing by default, returning the given value
+        as is. Child classes may override this method as required.
+        """
+        return value
+
     def instance_from_user_data(self, data):
         return SolrFieldInstance.from_user_data(self, data)
 
@@ -392,6 +400,7 @@ class SolrSchema(object):
         'solr.LatLonType':SolrPoint2Field,
         'solr.GeoHashField':SolrPoint2Field,
     }
+
     def __init__(self, f):
         """initialize a schema object from a
         filename or file-like object."""
@@ -441,10 +450,8 @@ class SolrSchema(object):
             name, class_name = field_type_node.attrib['name'], field_type_node.attrib['class']
         except KeyError, e:
             raise SolrError("Invalid schema.xml: missing %s attribute on fieldType" % e.args[0])
-        try:
-            field_class = self.solr_data_types[class_name]
-        except KeyError:
-            raise SolrError("Unknown field_class '%s'" % class_name)
+        #Obtain field type for given class. Defaults to generic SolrField.
+        field_class = self.solr_data_types.get(class_name, SolrField)
         return name, SolrFieldTypeFactory(field_class,
             **self.translate_attributes(field_type_node.attrib))
 


### PR DESCRIPTION
This allows Sunburnt to function on field types it doesn't know about, using strings as values for serialisation and deserialisation (as Solr stores them).  

This is helpful for fields where a Sunburnt implementation would be overly complicated and/or require extra dependencies on Sunburnt itself.  One specific example is that of the recently added solr.SpatialRecursivePrefixTreeFieldType for spatial searching (see http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4#Indexing) -- this field takes a variety of different spatial descriptors (coordinates, Well-Known Text (WKT), etc), so implementing a specific field is going to be rather complicated.  Using this pull request, users can work with such a field type, and do so simply using plain strings.  

Without this default fall-back, Sunburnt will error when attempting to communicate with a Solr instance with a field configured that it has no field type for -- even if that field type isn't used for an actual field.

Tests and documentation about default field translations included.
