### PR TITLE
Use schema spread across multiple files using xinclude

### DIFF
--- a/sunburnt/schema.py
+++ b/sunburnt/schema.py
@@ -141,7 +141,7 @@ class SolrField(object):
             elif self.name.endswith("*"):
                 self.wildcard_at_start = False
             else:
-                raise SolrError("Dynamic fields must have * at start or end of name (field %s)" % 
+                raise SolrError("Dynamic fields must have * at start or end of name (field %s)" %
                         self.name)
 
     def match(self, name):
@@ -153,7 +153,7 @@ class SolrField(object):
 
     def normalize(self, value):
         """ Normalize the given value according to the field type.
-        
+
         This method does nothing by default, returning the given value
         as is. Child classes may override this method as required.
         """
@@ -192,7 +192,7 @@ class SolrUnicodeField(SolrField):
         try:
             return unicode(value)
         except UnicodeError:
-            raise SolrError("%s could not be coerced to unicode (field %s)" % 
+            raise SolrError("%s could not be coerced to unicode (field %s)" %
                     (value, self.name))
 
 
@@ -207,7 +207,7 @@ class SolrBooleanField(SolrField):
             elif value.lower() == "false":
                 return False
             else:
-                raise ValueError("sorry, I only understand simple boolean strings (field %s)" % 
+                raise ValueError("sorry, I only understand simple boolean strings (field %s)" %
                         self.name)
         return bool(value)
 
@@ -217,7 +217,7 @@ class SolrBinaryField(SolrField):
         try:
             return str(value)
         except (TypeError, ValueError):
-            raise SolrError("Could not convert data to binary string (field %s)" % 
+            raise SolrError("Could not convert data to binary string (field %s)" %
                     self.name)
 
     def to_solr(self, value):
@@ -232,7 +232,7 @@ class SolrNumericalField(SolrField):
         try:
             v = self.base_type(value)
         except (OverflowError, TypeError, ValueError):
-            raise SolrError("%s is invalid value for %s (field %s)" % 
+            raise SolrError("%s is invalid value for %s (field %s)" %
                     (value, self.__class__, self.name))
         if v < self.min or v > self.max:
             raise SolrError("%s out of range for a %s (field %s)" %
@@ -424,10 +424,14 @@ class SolrSchema(object):
         return q
 
     def schema_parse(self, f):
-        try:
-            schemadoc = lxml.etree.parse(f)
-        except lxml.etree.XMLSyntaxError, e:
-            raise SolrError("Invalid XML in schema:\n%s" % e.args[0])
+        # hack as we might pass in an already parsed doc
+        if hasattr(f, 'getroot'):
+            schemadoc = f
+        else:
+            try:
+                schemadoc = lxml.etree.parse(f)
+            except lxml.etree.XMLSyntaxError, e:
+                raise SolrError("Invalid XML in schema:\n%s" % e.args[0])
 
         field_type_classes = {}
         for field_type_node in schemadoc.xpath("/schema/types/fieldType|/schema/types/fieldtype"):

--- a/sunburnt/sunburnt.py
+++ b/sunburnt/sunburnt.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+from os import path
+from lxml import etree
 import cStringIO as StringIO
 from itertools import islice
-import socket, time, urllib, urlparse
+import socket, time, urllib, urlparse, shutil, tempfile
 import warnings
 
 
@@ -153,7 +155,7 @@ class SolrConnection(object):
 
 
 class SolrInterface(object):
-    remote_schema_file = "admin/file/?file=schema.xml"
+
     def __init__(self, url, schemadoc=None, http_connection=None, mode='', retry_timeout=-1,
             max_length_get_url=MAX_LENGTH_GET_URL, format='xml'):
         self.conn = SolrConnection(url, http_connection, mode, retry_timeout, max_length_get_url, format)
@@ -163,17 +165,69 @@ class SolrInterface(object):
             raise ValueError("Unsupported format '%s': allowed are %s" %
                     (format, ','.join(allowed_formats)))
         self.format = format
+        self.file_cache = {}
         self.init_schema()
+
+    def make_file_url(self, filename):
+        return urlparse.urljoin(self.conn.url, 'admin/file/?file=') + filename
+
+    def get_file(self, filename):
+        # return remote file as StringIO and cache the contents
+        if filename not in self.file_cache:
+            r, c = self.conn.request(self.make_file_url(filename))
+            if r.status != 200:
+                raise EnvironmentError("Couldn't retrieve schema document from server - received status code %s\n%s" % (r.status, c))
+            self.file_cache[filename] = c
+        return StringIO.StringIO(self.file_cache[filename])
+
+    def save_file_cache(self, dirname):
+        # take the file cache and save to a directory
+        for filename in self.file_cache:
+            open(path.join(dirname, filename), 'w').write(self.file_cache[filename])
+
+    def get_xinclude_list_for_file(self, filename):
+        # return a list of xinclude elements in this file
+        tree = etree.parse(self.get_file(filename))
+        return tree.getroot().findall('{http://www.w3.org/2001/XInclude}include')
+
+    def get_file_and_included_files(self, filename):
+        # return a list containing this file, and all files this file includes
+        # via xinclude.  And do this recursively to ensure we have all we need.
+        file_list = [filename]
+        xinclude_list = self.get_xinclude_list_for_file(filename)
+        for xinclude_node in xinclude_list:
+            included_file = xinclude_node.get('href')
+            file_list += self.get_file_and_included_files(included_file)
+        return file_list
+
+    def get_parsed_schema_file_with_xincludes(self, filename):
+        # get the parsed schema file, and ensure we also get any files
+        # required for any xinclude.  If an xinclude is required, we need
+        # to save the files to the local disk before we call xinclude()
+        try:
+            file_list = self.get_file_and_included_files(filename)
+            if len(file_list) == 1:
+                # there are no xincludes, we can do this the easy way
+                schemadoc = etree.parse(self.get_file(filename))
+            else:
+                # save all contents to files, then load from file and xinclude
+                dirname = tempfile.mkdtemp()
+                try:
+                    self.save_file_cache(dirname)
+                    schemadoc = etree.parse(path.join(dirname, filename))
+                    schemadoc.xinclude()
+                finally:
+                    # delete dirname
+                    shutil.rmtree(dirname)
+        except etree.XMLSyntaxError, e:
+            raise SolrError("Invalid XML in schema:\n%s" % e.args[0])
+        return schemadoc
 
     def init_schema(self):
         if self.schemadoc:
             schemadoc = self.schemadoc
         else:
-            r, c = self.conn.request(
-                urlparse.urljoin(self.conn.url, self.remote_schema_file))
-            if r.status != 200:
-                raise EnvironmentError("Couldn't retrieve schema document from server - received status code %s\n%s" % (r.status, c))
-            schemadoc = StringIO.StringIO(c)
+            schemadoc = self.get_parsed_schema_file_with_xincludes('schema.xml')
         self.schema = SolrSchema(schemadoc, format=self.format)
 
     def add(self, docs, chunk=100, **kwargs):

--- a/sunburnt/test_sunburnt.py
+++ b/sunburnt/test_sunburnt.py
@@ -121,7 +121,11 @@ class MockConnection(object):
                                   headers=headers or {})
 
         if method == 'GET' and u.path.endswith('/admin/file/'):
-            return self.MockStatus(200), self.file_dict[params.get("file")[0]]
+            filename = params.get("file")[0]
+            if filename in self.file_dict:
+                return self.MockStatus(200), self.file_dict[filename]
+            else:
+                return self.MockStatus(404), None
 
         rc = self._handle_request(u, params, method, body, headers)
         if rc is not None:
@@ -297,6 +301,9 @@ schema_string_with_xinclude = \
   <xi:include href="schema_extra_fields.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
     <xi:fallback/>
   </xi:include>
+  <xi:include href="schema_not_available.xml" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:fallback/>
+  </xi:include>
   <defaultSearchField>text_field</defaultSearchField>
   <uniqueKey>int_field</uniqueKey>
 </schema>"""
@@ -356,7 +363,7 @@ def test_schema_file_cache_gets_filled():
 
 def test_all_xincludes_found():
     si = SolrInterface("http://test.example.com/", http_connection=XincludeMockConnection())
-    assert_equal(2, len(si.get_xinclude_list_for_file('schema.xml')))
+    assert_equal(3, len(si.get_xinclude_list_for_file('schema.xml')))
     assert_equal(0, len(si.get_xinclude_list_for_file('schema_extra_fields.xml')))
 
 


### PR DESCRIPTION
It is valid for Solr to use a schema spread across multiple files using
xinclude: https://wiki.apache.org/solr/SolrConfigXml#XInclude

lxml supports assembling them via the xinclude() method.  However it
can only do that on a set of files on the local filesystem.

With this commit, sunburnt will parse the schema.xml and see if there
are any xinclude elements in it.  If there are it will fetch the
required files via the Solr admin, save them all locally and use them.

Before this commit, the SolrInterface class would fetch the file and
pass it to the SolrSchema class where the parsing would be done.  But we
now have a loop where we parse a file we've fetched, and depending on
the results of the parse we might have to fetch more files.  So this
commit means we have to mix those two steps in a single class -
SolrInterface.

To keep the external interface to SolrSchema backwards compatible it can
take either a file like object which it will parse, or a tree object
that it will use directly.  Bit of a hack I know.