### PR TITLE
Facet ranges (take two)

### DIFF
--- a/sunburnt/schema.py
+++ b/sunburnt/schema.py
@@ -669,7 +669,7 @@ class SolrDelete(object):
 
 
 class SolrFacetCounts(object):
-    members= ["facet_dates", "facet_fields", "facet_queries"]
+    members= ["facet_dates", "facet_fields", "facet_queries", "facet_ranges"]
     def __init__(self, **kwargs):
         for member in self.members:
             setattr(self, member, kwargs.get(member, ()))


### PR DESCRIPTION
I originally opened this as pull request #76, but while I was working on it, I realized that Nagy's fork didn't really match the existing idioms for sunburnt, plus he had commits under the name "unknown", which doesn't look good in the git log or git blame.

So... I heavily rewrote this to make it match the existing sunburnt idioms, implemented all of the things you asked for (see below), and squashed it into 1 commit so that the commit history will be saner.

> 1) could you remove the logging call method in sunburnt.py

Done.

> 2) could you use the schema.py:solr_date object to check & store datetime objects? That will use mx.DateTime if available (which supports a wider range of dates than native Python datetime); it also ensures the codebase is consistent in datetime handling.

Done.

I also noticed that the code I brought in from Nagy's fork didn't match some of sunburnt's idioms, so I refactored to make my code blend in with yours better.

> 3) Can you add a check that range.start, range.gap, and range.end are
> (i) comparable - eg you've not got a numeric start and a datetime end.
> (ii) sanely positioned - eg that range.end > range.start etc

Done.

> 4) Is there a reason you've required that the range queries be only int or datetime? my reading of the solr docs suggests that they can be any field on which you can do range queries, ie floats should be ok - in fact even strings should be fine.

I believe it only applies to dates and numbers.

> As a generalization of the Date faceting described above, one can use the Range Faceting feature on any date field or any numeric field that supports range queries. This is particularly useful for the cases in the past where one might stitch together a series of range queries (as facet by query) for things like prices, etc.
>
> http://wiki.apache.org/solr/SimpleFacetParameters#Facet_by_Range

However, you are correct that sunburnt should support range facets on floats. That's fixed now.

> 5) not a blocker, but it might be nice to include support for facet.range.hardened, facet.range.other, facet.range.include

Done.

I also noticed that Nagy's branch documented support for "mincount" and "sort" arguments for range facets, but in fact Solr doesn't support these. The Solr documentation doesn't mention them, I can't find any references to it on Google, and my own testing on Solr 3.6.0 indicates that these arguments are ignored if applied to a facet range. Therefore, I have removed this erroneous bit from the documentation.

> 6) finally, could you add tests for the query generation?

Done.
