### PR TITLE
Add hl.q parameter to HighlightOptions

### DIFF
--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -794,7 +794,8 @@ class HighlightOptions(Options):
             "highlightMultiTerm":bool,
             "regex.slop":float,
             "regex.pattern":unicode,
-            "regex.maxAnalyzedChars":int
+            "regex.maxAnalyzedChars":int,
+            "q":unicode
             }
     def __init__(self, schema, original=None):
         self.schema = schema


### PR DESCRIPTION
Add hl.q parameter for HighlightOptions: http://wiki.apache.org/solr/HighlightingParameters#hl.q

Example usage highlighting the word "crime" in all documents after querying by "immigration":

```
si.query("immigration").highlight("text", useFastVectorHighlighter=True, highlightMultiTerm=True).highlight(q="crime").execute().highlighting
```
