### PR TITLE
Add support for TermVectorComponent

### DIFF
--- a/sunburnt/search.py
+++ b/sunburnt/search.py
@@ -817,7 +817,6 @@ class HighlightOptions(Options):
             self.fields = copy.copy(original.fields)
 
     def field_names_in_opts(self, opts, fields):
-        import pdb; pdb.set_trace()
         if fields:
             opts["hl.fl"] = ",".join(sorted(fields))
 


### PR DESCRIPTION
http://wiki.apache.org/solr/TermVectorComponent

Add support for term_vectors.

Example usage:

```
docs = si.query(phrase) \
          .terms('speaking').terms(tf=True) \
          .execute().result.docs
```

Currently assumes that the unique id is "id". I can clean up the xpath and add support for any unique id if you express interest in merging.

Thanks!
